### PR TITLE
Fixes #5, bug: open external links in a new tab instead of the same tab

### DIFF
--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,12 +1,11 @@
 "use client";
-import React, { useEffect, useState } from 'react'
-import { Card } from './ui/card'
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
-import Link from 'next/link'
-import { Button } from './ui/button'
+import React, { useEffect, useState } from "react";
+import { Card } from "./ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+import Link from "next/link";
+import { Button } from "./ui/button";
 
-const RepoCard =({data}:any) => {
-
+const RepoCard = ({ data }: any) => {
   const [showMore, setShowMore] = useState(false);
 
   return (
@@ -23,20 +22,25 @@ const RepoCard =({data}:any) => {
       </div>
       <div className="space-y-4 text-sm min-w-fit">
         <p>
-          {showMore ? data.description : data?.description?.split(' ').slice(0, 10).join(' ')}
-          {data.description?.split(' ').length > 10 && (
+          {showMore
+            ? data.description
+            : data?.description?.split(" ").slice(0, 10).join(" ")}
+          {data.description?.split(" ").length > 10 && (
             <span
               className="text-primary cursor-pointer"
               onClick={() => setShowMore(!showMore)}
-            >             
-              {showMore ? ' Read less' : ' Read more...'}
+            >
+              {showMore ? " Read less" : " Read more..."}
             </span>
           )}
         </p>
         <div className="flex flex-wrap gap-2">
           {data?.topics?.slice(0, 5).map((topic: any, index: any) => {
             return (
-              <span key={index} className="bg-muted rounded-full px-3 py-1 text-xs font-medium">
+              <span
+                key={index}
+                className="bg-muted rounded-full px-3 py-1 text-xs font-medium"
+              >
                 {topic}
               </span>
             );
@@ -49,40 +53,47 @@ const RepoCard =({data}:any) => {
               {data?.open_issues_count}
             </Link>
           </div>
-          <Button asChild variant="ghost" size="sm" className="gap-1 underline rounded-md underline-offset-2">
-            <Link href={data.html_url}>Repo Link</Link>
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            className="gap-1 underline rounded-md underline-offset-2"
+          >
+            <Link href={data.html_url} target="_blank">
+              Repo Link
+            </Link>
           </Button>
         </div>
       </div>
     </Card>
   );
+};
+function BugIcon(props: any) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m8 2 1.88 1.88" />
+      <path d="M14.12 3.88 16 2" />
+      <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+      <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
+      <path d="M12 20v-9" />
+      <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
+      <path d="M6 13H2" />
+      <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
+      <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
+      <path d="M22 13h-4" />
+      <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
+    </svg>
+  );
 }
-function BugIcon(props:any) {
-    return (
-      <svg
-        {...props}
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="m8 2 1.88 1.88" />
-        <path d="M14.12 3.88 16 2" />
-        <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
-        <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
-        <path d="M12 20v-9" />
-        <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
-        <path d="M6 13H2" />
-        <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
-        <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
-        <path d="M22 13h-4" />
-        <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
-      </svg>
-    )
-  }
-export default RepoCard
+export default RepoCard;


### PR DESCRIPTION
## Description

This PR updates the code to ensure external links in RepoCard open in a new tab instead of the same tab. This change improves user experience by keeping the current tab content intact while navigating to external pages.

## Changes

- Modified `<Link>` tags in RepoCard to include `target="_blank"` for external links.

## Motivation & Context

Previously, external links were opening in the same tab, potentially causing users to lose their place in the current application. Opening links in a new tab resolves this issue and provides a better browsing experience.

## How Has This Been Tested?

- Manual testing in various browsers (Chrome, Firefox) to ensure links open in a new tab.
- Verified that no internal links are affected.

## Screen Record

[Screencast from 2024-09-30 20-57-22.webm](https://github.com/user-attachments/assets/a35a2fa5-3696-489a-9ed6-453ed72d823b)

## Types of changes

- [ ] 🆕 New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the code and verified it works as expected.

## Linked Issues

- Fixes #5 

