### PR TITLE
Add functionality that links the clickable issues count to the respective repository's GitHub issues page

### DIFF
--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -49,7 +49,7 @@ const RepoCard = ({ data }: any) => {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 text-muted-foreground">
             <BugIcon className="w-5 h-5" />
-            <Link href="#" className="text-sm font-medium" prefetch={false}>
+            <Link href={`${data.html_url}/issues`} className="text-sm font-medium" prefetch={false}  target="_blank">
               {data?.open_issues_count}
             </Link>
           </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds functionality that on clicking the issues count user gets redirected to the respective repository's GitHub issues page
closes #28 

## Motivation and Context
This change is necessary to enhance user experience by making the clickable issues count functional. 
