### PR TITLE
Feature: Added star count and fork count to repo card

### DIFF
--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -56,13 +56,13 @@ const RepoCard = ({ data }: any) => {
           </div>
           <div className="flex items-center gap-2 text-muted-foreground">
             <ForkIcon className="w-5 h-5" />
-            <Link href={`${data.html_url}/issues`} className="text-sm font-medium" prefetch={false}  target="_blank">
+            <Link href={`${data.html_url}/forks`} className="text-sm font-medium" prefetch={false}  target="_blank">
               {data?.forks_count}
             </Link>
           </div>
           <div className="flex items-center gap-2 text-muted-foreground">
             <StarIcon className="w-5 h-5" />
-            <Link href={`${data.html_url}/issues`} className="text-sm font-medium" prefetch={false}  target="_blank">
+            <Link href={`${data.html_url}/stargazers`} className="text-sm font-medium" prefetch={false}  target="_blank">
               {data?.stargazers_count}
             </Link>
           </div>

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -4,6 +4,7 @@ import { Card } from "./ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import Link from "next/link";
 import { Button } from "./ui/button";
+import { BugIcon, ForkIcon, StarIcon } from "./ui/icons";
 
 const RepoCard = ({ data }: any) => {
   const [showMore, setShowMore] = useState(false);
@@ -53,6 +54,18 @@ const RepoCard = ({ data }: any) => {
               {data?.open_issues_count}
             </Link>
           </div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <ForkIcon className="w-5 h-5" />
+            <Link href={`${data.html_url}/issues`} className="text-sm font-medium" prefetch={false}  target="_blank">
+              {data?.forks_count}
+            </Link>
+          </div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <StarIcon className="w-5 h-5" />
+            <Link href={`${data.html_url}/issues`} className="text-sm font-medium" prefetch={false}  target="_blank">
+              {data?.stargazers_count}
+            </Link>
+          </div>
           <Button
             asChild
             variant="ghost"
@@ -68,32 +81,5 @@ const RepoCard = ({ data }: any) => {
     </Card>
   );
 };
-function BugIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="m8 2 1.88 1.88" />
-      <path d="M14.12 3.88 16 2" />
-      <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
-      <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
-      <path d="M12 20v-9" />
-      <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
-      <path d="M6 13H2" />
-      <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
-      <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
-      <path d="M22 13h-4" />
-      <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
-    </svg>
-  );
-}
+
 export default RepoCard;

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+export function BugIcon(props: any) {
+    return (
+        <svg
+        {...props}
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        >
+        <path d="m8 2 1.88 1.88" />
+        <path d="M14.12 3.88 16 2" />
+        <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+        <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
+        <path d="M12 20v-9" />
+        <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
+        <path d="M6 13H2" />
+        <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
+        <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
+        <path d="M22 13h-4" />
+        <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
+        </svg>
+    );
+}
+export function ForkIcon(props: any) {
+    return (
+        <svg
+        {...props}
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        >
+        <circle cx="12" cy="4" r="2" /> {/* Top circle */}
+        <circle cx="6" cy="18" r="2" /> {/* Left circle */}
+        <circle cx="18" cy="18" r="2" /> {/* Right circle */}
+        <path d="M12 6v4" /> {/* Line from top circle down */}
+        <path d="M12 10c0 2.5-4 2.5-4 5" /> {/* Left branch */}
+        <path d="M12 10c0 2.5 4 2.5 4 5" /> {/* Right branch */}
+        </svg>
+    );
+}
+  
+export function StarIcon(props: any) {
+    return (
+        <svg
+        {...props}
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        >
+        <polygon points="12 2 15 8.5 22 9.2 17 14 18.5 21 12 17.8 5.5 21 7 14 2 9.2 9 8.5 12 2" />
+        </svg>
+    );
+}


### PR DESCRIPTION
## Description
This pull request enhances the display of the Repo Card by adding the fork count and star count alongside the existing open issue count. This provides users with a more comprehensive overview of a repository's popularity and activity. It also refactors the code slightly, by adding a separate file for the icons.

## Motivation and Context
Previously, the repository information only displayed the open issue count. While this is useful, it doesn't provide a complete picture of a repository's engagement. Adding the fork count and star count offers valuable insights into:

* **Popularity:** The star count indicates how many users have shown interest in the repository.
* **Community engagement:** The fork count reflects how many users have created copies of the repository, potentially contributing to its development or using it as a basis for their own projects.

By including these additional metrics, users can gain a better understanding of a repository's overall health and activity level. This can help them make more informed decisions about whether to use, contribute to, or follow a particular repository.

## Screenshots:
<img width="396" alt="Screenshot 2024-10-06 at 1 13 37 PM" src="https://github.com/user-attachments/assets/39dd3322-54c5-41a7-9fe3-21fc1b3625c0">

